### PR TITLE
setup.py: fix installation on non-Ubuntu/Debian Linux distros

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,38 +72,21 @@ if "darwin" in sys.platform:
         'wofry>=1.0.19',
     )
 elif "linux" in sys.platform:
-    if "debian" in platform.platform(): # miniconda
-        INSTALL_REQUIRES = (
-            'setuptools',
-            'numpy>=1.16.0',
-            'sip>=4.19.8',
-            'PyQt5>=5.11.3',
-            'scipy',
-            'matplotlib',
-            'oasys-canvas-core>=0.0.10',
-            'oasys-widget-core>=0.0.5',
-            'silx>=0.7.0',
-            'hdf5plugin',
-            'srxraylib>=1.0.22',
-            'syned>=1.0.12',
-            'wofry>=1.0.19',
-        )
-    elif "Ubuntu" in platform.platform(): # default python.org
-        INSTALL_REQUIRES = (
-            'setuptools',
-            'numpy>=1.16.0',
-            'sip>=4.19.8',
-            'PyQt5>=5.11.3',
-            'scipy',
-            'matplotlib',
-            'oasys-canvas-core>=0.0.10',
-            'oasys-widget-core>=0.0.5',
-            'silx>=0.7.0',
-            'hdf5plugin',
-            'srxraylib>=1.0.22',
-            'syned>=1.0.12',
-            'wofry>=1.0.19',
-        )
+    INSTALL_REQUIRES = (
+        'setuptools',
+        'numpy>=1.16.0',
+        'sip>=4.19.8',
+        'PyQt5>=5.11.3',
+        'scipy',
+        'matplotlib',
+        'oasys-canvas-core>=0.0.10',
+        'oasys-widget-core>=0.0.5',
+        'silx>=0.7.0',
+        'hdf5plugin',
+        'srxraylib>=1.0.22',
+        'syned>=1.0.12',
+        'wofry>=1.0.19',
+    )
 else:
     INSTALL_REQUIRES = (
         'setuptools',


### PR DESCRIPTION
Without this patch, running `python setup.py install` results in

```
Traceback (most recent call last):
  File "setup.py", line 247, in <module>
    setup_package()
  File "setup.py", line 242, in setup_package
    install_requires=INSTALL_REQUIRES,
NameError: name 'INSTALL_REQUIRES' is not defined
```

on Linux distributions that are not Ubuntu or Debian...

Here at Diamond we use RHEL so we cannot install OASYS1 currently :cry: 